### PR TITLE
v0.2.5 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,3 @@
-#### 0.2.4 April 14 2019 ####
-* Upgraded to [Petabridge.Cmd v0.5.0](https://cmd.petabridge.com/articles/RELEASE_NOTES.html#v050-march-05-2019) so we could take advantage of the `cluster tail` command.
+#### 0.2.5 April 14 2019 ####
+* Upgraded to Akka.Cluster v1.3.12
+* Upgraded to [Akka.HealthCheck.Cluster v0.2.1](https://github.com/petabridge/akkadotnet-healthcheck/releases/tag/0.2.1)

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2019 Petabridge, LLC</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.2.4</VersionPrefix>
-    <PackageReleaseNotes>Upgraded to [Petabridge.Cmd v0.5.0](https://cmd.petabridge.com/articles/RELEASE_NOTES.html#v050-march-05-2019) so we could take advantage of the `cluster tail` command.</PackageReleaseNotes>
+    <VersionPrefix>0.2.5</VersionPrefix>
+    <PackageReleaseNotes>Upgraded to Akka.Cluster v1.3.12
+Upgraded to [Akka.HealthCheck.Cluster v0.2.1](https://github.com/petabridge/akkadotnet-healthcheck/releases/tag/0.2.1)</PackageReleaseNotes>
     <PackageIconUrl>
     </PackageIconUrl>
     <PackageProjectUrl>


### PR DESCRIPTION
#### 0.2.5 April 14 2019 ####
* Upgraded to Akka.Cluster v1.3.12
* Upgraded to [Akka.HealthCheck.Cluster v0.2.1](https://github.com/petabridge/akkadotnet-healthcheck/releases/tag/0.2.1)